### PR TITLE
Remove branch workflow trigger

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -2,7 +2,6 @@ name: Deployment
 
 on:
   push:
-    branches: [ "master" ]
     tags:
       - '/^v\d+\.\d+\.\d+/'
 


### PR DESCRIPTION
This fixes a bug where the deployment workflow was triggered when a push is made to the master branch. The aforementioned workflow shall only trigger once a release tag has been made.